### PR TITLE
feat: use union replace enum  @acgotaku

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -78,7 +79,7 @@ func (t *TypeScriptGRPCGatewayGenerator) Generate(req *plugin.CodeGeneratorReque
 		needToGenerateFetchModule = needToGenerateFetchModule || fileData.Services.NeedsFetchModule()
 	}
 
-	if needToGenerateFetchModule {
+	if needToGenerateFetchModule && !t.fetchModuleExists() {
 		// generate fetch module
 		fetchTmpl := GetFetchModuleTemplate()
 		log.Debugf("generate fetch template")
@@ -113,6 +114,14 @@ func (t *TypeScriptGRPCGatewayGenerator) generateFile(fileData *data.File, tmpl 
 		InsertionPoint: nil,
 		Content:        &content,
 	}, nil
+}
+
+func (t *TypeScriptGRPCGatewayGenerator) fetchModuleExists() bool {
+	fileName := filepath.Join(t.Registry.FetchModuleDirectory, t.Registry.FetchModuleFilename)
+	if _, err := os.Stat(fileName); errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	return true
 }
 
 func (t *TypeScriptGRPCGatewayGenerator) generateFetchModule(tmpl *template.Template) (*plugin.CodeGeneratorResponse_File, error) {

--- a/generator/template.go
+++ b/generator/template.go
@@ -89,6 +89,7 @@ type OneOf<T> =
         : never)
     : never);
 {{end}}
+export type ValuesOf<T> = T[keyof T];
 {{- if .Enums}}{{include "enums" .Enums}}{{end}}
 {{- if .Messages}}{{include "messages" .Messages}}{{end}}
 {{- if .Services}}{{include "services" .Services}}{{end}}
@@ -556,7 +557,7 @@ func tsType(r *registry.Registry, fieldType data.Type) string {
 		typeStr = mapScalaType(info.Type)
 	} else if !info.IsExternal {
     if typeInfo.ProtoType == descriptorpb.FieldDescriptorProto_TYPE_ENUM {
-      typeStr = fmt.Sprintf("typeof %s[keyof typeof %s]", typeInfo.PackageIdentifier, typeInfo.PackageIdentifier)
+      typeStr = fmt.Sprintf("ValuesOf<typeof %s>", typeInfo.PackageIdentifier)
     } else {
       typeStr = typeInfo.PackageIdentifier
     }

--- a/generator/template.go
+++ b/generator/template.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
-
+  descriptorpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/Masterminds/sprig"
@@ -23,11 +23,11 @@ import * as {{.ModuleIdentifier}} from "{{.SourceFile}}"{{end}}
 {{end}}
 
 {{define "enums"}}{{range .}}
-export enum {{.Name}} {
+export const {{.Name}} = {
 {{- range .Values}}
-  {{.}} = "{{.}}",
+  {{.}}: "{{.}}",
 {{- end}}
-}
+} as const;
 {{end}}{{end}}
 
 {{define "messages"}}
@@ -45,7 +45,7 @@ export type {{.Name}} = Base{{.Name}}
 {{- else -}}
 export type {{.Name}} = {
 {{- range .Fields}}
-  {{fieldName .Name}}?: {{tsType .}}
+  {{fieldName .Name}}?: {{tsType .}};
 {{- end}}
 }
 {{end}}
@@ -555,7 +555,12 @@ func tsType(r *registry.Registry, fieldType data.Type) string {
 	if strings.Index(info.Type, ".") != 0 {
 		typeStr = mapScalaType(info.Type)
 	} else if !info.IsExternal {
-		typeStr = typeInfo.PackageIdentifier
+    if typeInfo.ProtoType == descriptorpb.FieldDescriptorProto_TYPE_ENUM {
+      typeStr = fmt.Sprintf("typeof %s[keyof typeof %s]", typeInfo.PackageIdentifier, typeInfo.PackageIdentifier)
+    } else {
+      typeStr = typeInfo.PackageIdentifier
+    }
+		
 	} else {
 		typeStr = mapWellKnownType(info.Type)
 		if typeStr == "" {


### PR DESCRIPTION
1. 使用union 类型 替换 enum

具体效果如下：

enum编译结果
```ts
export enum BookingStatus {
  UNKNOWN_BOOKING_STATUS = "UNKNOWN_BOOKING_STATUS",
  REQUESTED = "REQUESTED",
  STANDBY = "STANDBY",
  DECLINED = "DECLINED",
  CONFIRMED = "CONFIRMED",
  WITHDRAWN_BY_TRAVELER = "WITHDRAWN_BY_TRAVELER",
  CANCELED_BY_TRAVELER = "CANCELED_BY_TRAVELER",
  CANCELED_BY_SUPPLIER = "CANCELED_BY_SUPPLIER",
  CHANGED_BY_SUPPLIER = "CHANGED_BY_SUPPLIER",
  CANCEL_PENDING = "CANCEL_PENDING",
  CANCEL_FAILED = "CANCEL_FAILED",
  INVALID = "INVALID",
}

export type ListBookingsRequest = {
  bookingStatuses?: BookingStatus[];
};
```

union 编译结果

```ts
export const BookingStatus = {
  UNKNOWN_BOOKING_STATUS: "UNKNOWN_BOOKING_STATUS",
  REQUESTED: "REQUESTED",
  STANDBY: "STANDBY",
  DECLINED: "DECLINED",
  CONFIRMED: "CONFIRMED",
  WITHDRAWN_BY_TRAVELER: "WITHDRAWN_BY_TRAVELER",
  CANCELED_BY_TRAVELER: "CANCELED_BY_TRAVELER",
  CANCELED_BY_SUPPLIER: "CANCELED_BY_SUPPLIER",
  CHANGED_BY_SUPPLIER: "CHANGED_BY_SUPPLIER",
  CANCEL_PENDING: "CANCEL_PENDING",
  CANCEL_FAILED: "CANCEL_FAILED",
  INVALID: "INVALID",
} as const;

export type ListBookingsRequest = {
  bookingStatuses?: typeof BookingStatus[keyof typeof BookingStatus][];
};
```

enum有各种缺点不推荐使用，理由可以参考我博客 https://blog.icehoney.me/posts/2022-07-04-typescript-enum/

但是golang 我写的不是很好，还得麻烦检查检查下有没有边界条件没处理好。
